### PR TITLE
Enforce minimum required version

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -13,6 +13,10 @@ if(params.help) {
     return
 }
 
+if( !nextflow.version.matches('21.0+') ) {
+    error "This workflow requires Nextflow version 21.0 or greater -- You are running version $nextflow.version"
+}
+
 log.info "dMRIqc_flow"
 log.info "==========="
 log.info ""
@@ -37,7 +41,7 @@ for (String item : theArr) {
 
 if (profiles.get(0) != "input_qc" && profiles.get(0) != "tractoflow_qc_light" && profiles.get(0) != "tractoflow_qc_all" && profiles.get(0) != "rbx_qc" && profiles.get(0) != "disconets_qc")
 {
-    error "Error ~ Please select a profile (-profile): input_qc, tractoflow_qc_light, tractoflow_qc_all or rbx_qc."
+    error "Error ~ Please select a profile (-profile): input_qc, tractoflow_qc_light, tractoflow_qc_all, rbx_qc or disconets_qc."
 }
 
 

--- a/main.nf
+++ b/main.nf
@@ -602,7 +602,7 @@ Channel
 
 tractograms
     .combine(t1_warped_for_tracking, by:[0,1])
-    .groupTuple()
+    .groupTuple(sort:true)
     .map{it -> it[2..-1]}
     .set{tracking_t1}
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,3 +1,5 @@
+manifest.nextflowVersion = '21.1+'
+
 process {
     publishDir = {"./results_QC/$task.process"}
     scratch = false


### PR DESCRIPTION
Force minimum required nextflow version. An error will be raised if the requirement is not met. 

The new line in `nextflow.config` file simply prints a warning when the requirement is not met, while the change in `main.nf` forces the pipeline to abort.